### PR TITLE
Use base and broadcast to reflect actual IPs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,6 +164,18 @@ class IPAddress extends Component {
             <span className="value">{details.mask}</span>
             <span className="label">Netmask</span>
           </span>
+          <span className="base">
+            <span className="value">{details.base}</span>
+            <span className="label">CIDR Base IP</span>
+          </span>
+          <span className="broadcast">
+            <span className="value">{details.broadcast}</span>
+            <span className="label">Broadcast IP</span>
+          </span>
+          <span className="count">
+            <span className="value">{details.size.toLocaleString()}</span>
+            <span className="label">Count</span>
+          </span>
           <span className="first">
             <span className="value">{details.first}</span>
             <span className="label">First Usable IP</span>
@@ -171,10 +183,6 @@ class IPAddress extends Component {
           <span className="last">
             <span className="value">{details.last}</span>
             <span className="label">Last Usable IP</span>
-          </span>
-          <span className="count">
-            <span className="value">{details.size.toLocaleString()}</span>
-            <span className="label">Count</span>
           </span>
         </div>
       </div>

--- a/src/style.scss
+++ b/src/style.scss
@@ -101,19 +101,27 @@ body {
     div.details {
       span.netmask {
         display: inline-block;
-        width: 20%;
+        width: 15%;
       }
-      span.first {
+      span.base {
         display: inline-block;
-        width: 20%;
+        width: 15%;
       }
-      span.last {
+      span.broadcast {
         display: inline-block;
-        width: 20%;
+        width: 15%;
       }
       span.count {
         display: inline-block;
-        width: 20%;
+        width: 15%;
+      }
+      span.first {
+        display: inline-block;
+        width: 15%;
+      }
+      span.last {
+        display: inline-block;
+        width: 15%;
       }
       span.value {
         font-size: modular-scale(1);


### PR DESCRIPTION
Base and broadcast are already provided in the library. 
Count moved left where it better reflects the maximum size of the CIDR.
Usable IPs are much more clear now.
Adjusted spacing of the styling to accommodate more columns.

Fixes #65 