### PR TITLE
Improve accessibility for visually impaired

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,7 @@ class IPAddress extends Component {
                 className="octet"
                 type="text"
                 data-octet={octet}
+                aria-label={"octet "+ octet}
                 onChange={this.handleChange}
                 onKeyDown={this.handleKeyDown}
                 onPaste={this.handlePaste}
@@ -128,6 +129,7 @@ class IPAddress extends Component {
             className="cidr"
             type="text"
             data-octet="cidr"
+            aria-label="cidr mask"
             onChange={this.handleChange}
             onKeyDown={this.handleKeyDown}
             onPaste={this.handlePaste}

--- a/src/style.scss
+++ b/src/style.scss
@@ -93,7 +93,6 @@ body {
           }
           ol li.bit.masked {
             background-color: lighten($color_e, $octet_lighten);
-            color: lighten($color_e, 22%);
           }
         }
       }
@@ -124,7 +123,7 @@ body {
         text-transform: uppercase;
         font-size: modular-scale(2);
         font-weight: bold;
-        color: #779;
+        color: #656582;
       }
     }
   }


### PR DESCRIPTION
Fixes #69

Three minor changes for accessibility:

- [x] Added `aria-label` properties `octet 1-4` and `cidr mask` to the input fields.
- [x] Only lighten the background of host bit masks to improve contrast.
- [x] Slightly darken the font color from #779 to #656582 on the output IP labels.