### PR TITLE
Added Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+cidr.png
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:13.14.0-alpine as build
+
+WORKDIR /build
+COPY .babelrc package.json webpack.config.js yarn.lock ./
+
+RUN set -eux \
+    & apk add \
+        --no-cache \
+        yarn \
+	python3
+
+RUN yarn
+COPY src ./src
+RUN yarn run build
+
+FROM nginx:1.25.5-alpine as nginx
+
+COPY --from=build /build/dist/  /usr/share/nginx/html
+EXPOSE 80/tcp

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Manually building the static content into the `dist/` directory can be done with
 $ yarn run build
 ```
 
+## Docker
+
+You can build a Docker Image from an included Dockerfile and run it as a container:
+
+```bash
+docker build -t cidr.xyz:0.1 .
+docker run -d --rm -p 80:80 cidr.xyz:0.1
+```
+
 ## Deployment
 
 Deployment is automated from `master` branch via Netlify


### PR DESCRIPTION
Containerized cidr.xyz into a small Docker Image that is ~50 Mb in size. You can build it locally or push the Image to Dockerhub so that people use an already existing Docker Image.